### PR TITLE
Add suport of arm64 using buildx

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -23,9 +23,14 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USER }}
           password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
       - name: Build docker image
         run: |
           just VERSION=${{ steps.theVersion.outputs.theVersion }} _build-latest
+      - name: Release docker image
+        run: |
+          just docker_image_release
       - name: Upload Helm artifact
         uses: actions/upload-artifact@v2
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
 FROM golang:1.17.7-alpine as build
 
-ARG ARCH=amd64
+RUN if [ `uname -m` = "aarch64" ] ; then \
+       ARCH="arm64"; \
+    else \
+       ARCH="amd64"; \
+    fi
 ARG PKG=github.com/open-policy-agent/kube-mgmt
 ARG VERSION=local
 ARG COMMIT=local

--- a/justfile
+++ b/justfile
@@ -18,7 +18,13 @@ _build-latest: build
     LATEST="$(jq -r .builds[0].imageName skaffold.json):latest"
     CURRENT="$(jq -r .builds[0].tag skaffold.json)"
     docker tag $CURRENT $LATEST
-    docker push $LATEST
+
+docker_image_release: 
+    #!/usr/bin/env bash
+    set -euxo pipefail
+    LATEST="$(jq -r .builds[0].imageName skaffold.json):latest"
+    CURRENT="$(jq -r .builds[0].tag skaffold.json)"
+    docker buildx build --platform linux/arm64,linux/amd64 -t $LATEST -t $CURRENT --push .
 
 @test-go:
     ./test/go/test.sh

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -11,7 +11,7 @@ build:
           VERSION: "{{.VERSION}}"
           COMMIT: "{{.COMMIT}}"
   local:
-    push: true
+    push: false
     useBuildkit: true
 profiles:
   - name: local


### PR DESCRIPTION
Hi

Package Owner: Subham Kumar

PR change Details:

Patch Details: Following files have been changed:

.github/workflows/release.yaml, justfile, Dockerfile:- Added buildx support to release docker images for arm64 platform.
PR Description: Here is my commit message :
Add arm support using buildx

PR Description:

The following file has been created and modified:

Added arm support using buildx in .github/workflows/relese.yaml, justfile, Dockerfile to build and release docker image for arm64 platform.

Signed-off-by: odidev odidev@puresoftware.com

Reviewer: Akhand Pratap singh
Thanks
Subham Kumar